### PR TITLE
Added mandatory `data_length` parameter to `user_defined()` constructor.

### DIFF
--- a/netlink-rs/src/socket/msg.rs
+++ b/netlink-rs/src/socket/msg.rs
@@ -144,14 +144,16 @@ pub struct NlMsgHeader {
 }
 
 impl NlMsgHeader {
-    pub fn user_defined(t: u16) -> NlMsgHeader {
-        NlMsgHeader {
+    pub fn user_defined(t: u16, data_length: u32) -> NlMsgHeader {
+        let mut h = NlMsgHeader {
             msg_length: nlmsg_header_length() as u32,
             nl_type: t,
             flags: Flags::Request.into(),
             seq: 0,
             pid: 0,
-        }
+        };
+        h.data_length(data_length);
+        h
     }
 
     pub fn request() -> NlMsgHeader {


### PR DESCRIPTION
Since there is no documentation, it is very easy to miss that the
msg_length header is supposed to be set to the length of header +
message. By default, it is set to the header length only.

Forgetting to set the message length results in just messages being
truncated and causing errors that are hard to interpret. Adding the
`data_length` parameter at least forces that field to be set.